### PR TITLE
Remove unnecessary checklist items

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -28,9 +28,7 @@ module.exports = {
   checklists: {
     change: [
       'Test code changes on the robot (if possible).',
-      'Verify that significant changes have tests and pass successfully.',
-      'Rebase commits into one if neccessary. Verify that it is appropriatly titled.',
-      'Request code reviews from other team members working on the same area of the robot (a review from @SouthEugeneRoboticsTeam/reviewers is required).'
+      'Verify that significant changes have tests and pass successfully.'
     ],
     release: [
       'Test all code changes on the robot (if possible).',

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -28,7 +28,8 @@ module.exports = {
   checklists: {
     change: [
       'Test code changes on the robot (if possible).',
-      'Verify that significant changes have tests and pass successfully.'
+      'Verify that significant changes have tests and pass successfully.',
+      'Ensure this pull request is appropriately titled.'
     ],
     release: [
       'Test all code changes on the robot (if possible).',


### PR DESCRIPTION
@andrewda How does the release process work, is it automatic? `#4` is unnecessary since that's what the codeowners file is for and `#3` is meh since we can just squash. I disagree that the burden to make nice commits should be on the contributor, it should be on the maintainer. What do you think?